### PR TITLE
Remove exposed Spotter Token

### DIFF
--- a/.github/workflows/spotter-ci.yml
+++ b/.github/workflows/spotter-ci.yml
@@ -8,8 +8,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Scan Ansible content with different inputs
-        uses: xlab-steampunk/spotter-action@5.0.0
+        uses: xlab-steampunk/spotter-action@5.2.0
         with:
-          endpoint: https://api.spotter.steampunk.si/api
-          api_token: eb05a00b693f4ac42d98616ec5ef60ab218742736b75defaca9dca866cfd46bd0f5da4ade45cdeacfa8369cd7689071ccc1a3356f25193ec7a6a2f97fcf9f7f8
+          api_token: ${{ secrets.SPOTTER_TOKEN }}
           ansible_version: 2.16


### PR DESCRIPTION
**What has changed**
Spotter endpoint removed as the default one was being used.
Moved the spotter token to secrets.
Updated the spotter action version.

**Why were changes needed**
Removed the spotter token so as not to be abused by an outside actor (as this is a public repo).

More info on Steampunk spotter github action usage:
https://github.com/xlab-steampunk/spotter-action?tab=readme-ov-file#usage

Creating github secrets:
https://docs.github.com/en/actions/how-tos/security-for-github-actions/security-guides/using-secrets-in-github-actions

@hammer-redhat Could you please remove the token in the steampunk spotter account (web UI) and generate a new one if this PR is merged? 